### PR TITLE
Remove Russian flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Jouele is a simple and beautiful audio player for the web.
 
 [Project page](http://ilyabirman.net/projects/jouele/)
 
-[Russian translation of the documentation](https://github.com/ilyabirman/Jouele/blob/master/readme-ru.md) :ru:
+[ru] [Документация по русски](https://github.com/ilyabirman/Jouele/blob/master/readme-ru.md)
 
 ## Famous 2-step Setup
 ```html


### PR DESCRIPTION
Для обозначения языка лучше использовать ISO код, а не флаг (https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes). Языки не соотносятся напрямую со странами. Например, английский удобнее обозначать `[en]`, а не британским, канадским или австралийским флагом. На русском языке тоже говорят не только в России, но и граждане стран под другими флагами. Это и их язык тоже, поэтому вместо флага лучше использовать принятый для языков код.