### PR TITLE
tabular-nums for progress

### DIFF
--- a/src/jouele.css
+++ b/src/jouele.css
@@ -272,6 +272,14 @@
     -moz-user-select: none;
     -ms-user-select: none;
     user-select: none;
+    font-feature-settings: 'tnum';
+}
+
+@supports (font-variant-numeric: tabular-nums) {
+    .jouele-info-time {
+        font-feature-settings: 'tnum';
+        font-variant-numeric: tabular-nums;
+    }
 }
 
 .jouele-info-time__current {


### PR DESCRIPTION
`tabular-nums` displays numbers with equal sizing, so browser can optimize render for it.

example in twit: https://twitter.com/jeetiss/status/1235827797081223169